### PR TITLE
refactor: optimize TypeScript build process in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,8 +16,11 @@ COPY --chown=node:node . .
 # installing all dependencies (including dev deps for TypeScript compilation)
 RUN npm ci
 
-# build the TypeScript application with memory optimization
-RUN NODE_OPTIONS='--max-old-space-size=1024' npm run build:render
+# Increase Node heap during build to avoid OOM on Render builders
+ENV NODE_OPTIONS=--max-old-space-size=2048
+
+# build the TypeScript application
+RUN npm run build:render
 
 # container exposed network port number
 EXPOSE 3000

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "start": "npm run serve",
     "serve": "node -r dotenv/config build/server.js",
     "build": "npm run clean && npm run build-ts",
-    "build:render": "npm run clean && NODE_OPTIONS='--max-old-space-size=1024' tsc -p tsconfig.prod.json",
+    "build:render": "npm run clean && tsc -p tsconfig.prod.json",
     "start:prod": "NODE_ENV=production npm run serve",
     "watch": "npx concurrently -k -p \"[{name}]\" -n \"TypeScript,Node\" -c \"yellow.bold,cyan.bold,green.bold\" \"npm run watch-ts\" \"npm run watch-node\"",
     "watch-node": "nodemon -r dotenv/config build/server.js",


### PR DESCRIPTION
- Increase Node.js memory limit during build to prevent out-of-memory errors on Render builders.
- Remove inline memory option from build command in package.json for cleaner configuration.
- Update Dockerfile to set NODE_OPTIONS as an environment variable for better maintainability.

These changes enhance the build process efficiency and stability in the Docker environment.